### PR TITLE
Ignore 'Warning: no info dictionary' in data_dump

### DIFF
--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -193,7 +193,10 @@ module ActivePdftk
         end
         stdin.close
         @output.puts stdout.read if @output && !@output.is_a?(String)
-        raise(CommandError, {:stderr => @error, :cmd => cmd}) unless (@error = stderr.read).empty?
+        # We ignore 'no info dictionary' warning since it doesn't affect the integrity of the PDF
+        # and handling this warning as an error prevents us from accessing the other metadata
+        raise(CommandError, {:stderr => @error, :cmd => cmd, :stdout => stdout, :output => @output}) unless
+          ((@error = stderr.read).empty? || @error == "Warning: no info dictionary found\n")
       end
       if dsl_statements[:operation].to_s.match(/burst|unpack_files/) && dsl_statements[:output].nil?
         Dir.tmpdir


### PR DESCRIPTION
This allows us to read the remaining metadata instead of raising an
exception. We need this to read the page count in pdfs without an info
dictionary.

[1deg/application-server#4105]