### PR TITLE
Small method change for no info dictionary warning

### DIFF
--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -196,7 +196,7 @@ module ActivePdftk
         # We ignore 'no info dictionary' warning since it doesn't affect the integrity of the PDF
         # and handling this warning as an error prevents us from accessing the other metadata
         raise(CommandError, {:stderr => @error, :cmd => cmd, :stdout => stdout, :output => @output}) unless
-          ((@error = stderr.read).empty? || @error == "Warning: no info dictionary found\n")
+          ((@error = stderr.read).empty? || @error.include?("Warning: no info dictionary found"))
       end
       if dsl_statements[:operation].to_s.match(/burst|unpack_files/) && dsl_statements[:output].nil?
         Dir.tmpdir


### PR DESCRIPTION
Tiny change from using '==' to check for the warning message to '.include?'

[1deg/application-server#4105]